### PR TITLE
Add initial authentication and Google Tasks connection

### DIFF
--- a/src/main/java/somethingrandom/dataaccess/google/APIProvider.java
+++ b/src/main/java/somethingrandom/dataaccess/google/APIProvider.java
@@ -1,0 +1,23 @@
+package somethingrandom.dataaccess.google;
+
+import org.json.JSONObject;
+import somethingrandom.dataaccess.google.auth.AuthenticationException;
+
+import java.io.IOException;
+
+public interface APIProvider {
+    JSONObject request(String url) throws IOException, AuthenticationException;
+
+    class Constant implements APIProvider {
+        private final String source;
+
+        public Constant(String source) {
+            this.source = source;
+        }
+
+        @Override
+        public JSONObject request(String url) {
+            return new JSONObject(source);
+        }
+    }
+}

--- a/src/main/java/somethingrandom/dataaccess/google/APIProvider.java
+++ b/src/main/java/somethingrandom/dataaccess/google/APIProvider.java
@@ -19,43 +19,13 @@ public interface APIProvider {
      * The request will be made with the required authentication, along with
      * the specified request body.
      *
+     * @param body The data to accompany the request.
      * @param url The URL to request.
      * @return The parsed JSON API result.
      * @throws IOException on network errors
      * @throws AuthenticationException if the token could not be refreshed
      */
-    JSONObject request(Body body, String url) throws IOException, AuthenticationException;
-
-    /**
-     * Represents the additional data to be sent with the request.
-     * <p>
-     * This entails the request method, content, and MIME type.
-     */
-    interface Body {
-        String getMethod();
-        String getContent();
-        String getMimeType();
-    }
-
-    /**
-     * A GetBody is a Body with no content using the GET method.
-     */
-    class GetBody implements Body {
-        @Override
-        public String getMethod() {
-            return "GET";
-        }
-
-        @Override
-        public String getContent() {
-            return null;
-        }
-
-        @Override
-        public String getMimeType() {
-            return null;
-        }
-    }
+    JSONObject request(APIRequestBody body, String url) throws IOException, AuthenticationException;
 
     class Constant implements APIProvider {
         private final String source;
@@ -65,7 +35,7 @@ public interface APIProvider {
         }
 
         @Override
-        public JSONObject request(Body body, String url) {
+        public JSONObject request(APIRequestBody body, String url) {
             return new JSONObject(source);
         }
     }

--- a/src/main/java/somethingrandom/dataaccess/google/APIProvider.java
+++ b/src/main/java/somethingrandom/dataaccess/google/APIProvider.java
@@ -5,8 +5,57 @@ import somethingrandom.dataaccess.google.auth.AuthenticationException;
 
 import java.io.IOException;
 
+/**
+ * An APIProvider abstracts the process of connecting to an API.
+ * <p>
+ * The singular 'request' method is used to connect to the Google API. A full
+ * URL is provided, and the parsed result is returned, so it's easy to replace
+ * HTTP libraries or to test without involving HTTP.
+ */
 public interface APIProvider {
-    JSONObject request(String url) throws IOException, AuthenticationException;
+    /**
+     * Makes the HTTP request to the provided URL.
+     * <p>
+     * The request will be made with the required authentication, along with
+     * the specified request body.
+     *
+     * @param url The URL to request.
+     * @return The parsed JSON API result.
+     * @throws IOException on network errors
+     * @throws AuthenticationException if the token could not be refreshed
+     */
+    JSONObject request(Body body, String url) throws IOException, AuthenticationException;
+
+    /**
+     * Represents the additional data to be sent with the request.
+     * <p>
+     * This entails the request method, content, and MIME type.
+     */
+    interface Body {
+        String getMethod();
+        String getContent();
+        String getMimeType();
+    }
+
+    /**
+     * A GetBody is a Body with no content using the GET method.
+     */
+    class GetBody implements Body {
+        @Override
+        public String getMethod() {
+            return "GET";
+        }
+
+        @Override
+        public String getContent() {
+            return null;
+        }
+
+        @Override
+        public String getMimeType() {
+            return null;
+        }
+    }
 
     class Constant implements APIProvider {
         private final String source;
@@ -16,7 +65,7 @@ public interface APIProvider {
         }
 
         @Override
-        public JSONObject request(String url) {
+        public JSONObject request(Body body, String url) {
             return new JSONObject(source);
         }
     }

--- a/src/main/java/somethingrandom/dataaccess/google/APIRequestBody.java
+++ b/src/main/java/somethingrandom/dataaccess/google/APIRequestBody.java
@@ -1,0 +1,87 @@
+package somethingrandom.dataaccess.google;
+
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
+
+/**
+ * Represents the additional data to be sent with the request.
+ * <p>
+ * This entails the request method, content, and MIME type.
+ */
+public interface APIRequestBody {
+    /**
+     * Gets the HTTP method that should be used for the request.
+     *
+     * This will probably be "GET" or "POST".
+     *
+     * @return the method to use
+     */
+    String getMethod();
+
+    /**
+     * Gets the content of this request body, or null if there isn't any.
+     *
+     * @return the content of the body
+     */
+    @Nullable
+    String getContent();
+
+    /**
+     * Gets the MIME type of the body.
+     *
+     * This will be used in the request's Content-Type.
+     *
+     * @return the MIME type associated with the request
+     */
+    String getMimeType();
+
+    /**
+     * A GetBody is a Body with no content using the GET method.
+     */
+    class GetBody implements APIRequestBody {
+        @Override
+        public String getMethod() {
+            return "GET";
+        }
+
+        @Override
+        public String getContent() {
+            return null;
+        }
+
+        @Override
+        public String getMimeType() {
+            return null;
+        }
+    }
+
+    /**
+     * A JSONBody is a Body containing a JSONObject.
+     *
+     * It uses the method specified in the constructor.
+     */
+    class JSONBody implements APIRequestBody {
+        private final String method;
+        private final JSONObject payload;
+
+        public JSONBody(String method, JSONObject payload) {
+            this.method = method;
+            this.payload = payload;
+        }
+
+        @Override
+        public String getMethod() {
+            return method;
+        }
+
+        @Override
+        public String getContent() {
+            return this.payload.toString();
+        }
+
+        @Override
+        public String getMimeType() {
+            return "application/json";
+        }
+    }
+}

--- a/src/main/java/somethingrandom/dataaccess/google/APIRequestBody.java
+++ b/src/main/java/somethingrandom/dataaccess/google/APIRequestBody.java
@@ -11,7 +11,7 @@ import org.json.JSONObject;
 public interface APIRequestBody {
     /**
      * Gets the HTTP method that should be used for the request.
-     *
+     * <p>
      * This will probably be "GET" or "POST".
      *
      * @return the method to use
@@ -28,7 +28,7 @@ public interface APIRequestBody {
 
     /**
      * Gets the MIME type of the body.
-     *
+     * <p>
      * This will be used in the request's Content-Type.
      *
      * @return the MIME type associated with the request
@@ -57,7 +57,7 @@ public interface APIRequestBody {
 
     /**
      * A JSONBody is a Body containing a JSONObject.
-     *
+     * <p>
      * It uses the method specified in the constructor.
      */
     class JSONBody implements APIRequestBody {

--- a/src/main/java/somethingrandom/dataaccess/google/GoogleDataAccessObject.java
+++ b/src/main/java/somethingrandom/dataaccess/google/GoogleDataAccessObject.java
@@ -1,0 +1,55 @@
+package somethingrandom.dataaccess.google;
+
+import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.NotNull;
+import somethingrandom.dataaccess.google.auth.Token;
+import somethingrandom.dataaccess.google.tasks.GoogleTasksDataAccessObject;
+import somethingrandom.dataaccess.google.tasks.TaskList;
+import somethingrandom.dataaccess.google.tasks.TaskAccount;
+import somethingrandom.entity.Item;
+import somethingrandom.usecase.AddItemDataAccessInterface;
+import somethingrandom.usecase.DataAccessException;
+
+import java.util.Optional;
+
+/**
+ * GoogleDataAccessObject is a generic data access object to interact
+ * with either Google Keep or Google Tasks.
+ * <p>
+ * It automatically selects the backend corresponding: Keep for reference
+ * items, and Tasks for others.
+ */
+public class GoogleDataAccessObject implements AddItemDataAccessInterface {
+    private final GoogleTasksDataAccessObject tasksDAO;
+
+    /**
+     * Creates a new data access object that connects to Google APIs.
+     *
+     *
+     * @param client The HTTP client to use to connect.
+     * @param token The token to authenticate with.
+     * @param taskListName The identifier of the task list to use.
+     * @throws DataAccessException if the task list does not exist.
+     */
+    public GoogleDataAccessObject(OkHttpClient client, Token token, String taskListName) throws DataAccessException {
+        OkHttpAPIProvider provider = new OkHttpAPIProvider(client, token);
+        this.tasksDAO = createTasksDAO(provider, taskListName);
+    }
+
+    @NotNull
+    private static GoogleTasksDataAccessObject createTasksDAO(APIProvider provider, String taskListName) throws DataAccessException {
+        TaskAccount account = new TaskAccount(provider);
+
+        Optional<TaskList> tl = account.findTaskListByIdentifier(taskListName);
+        if (tl.isEmpty()) {
+            throw new DataAccessException("Specified task list does not exist");
+        }
+
+        return new GoogleTasksDataAccessObject(tl.get());
+    }
+
+    @Override
+    public void save(Item item) throws DataAccessException {
+        tasksDAO.save(item);
+    }
+}

--- a/src/main/java/somethingrandom/dataaccess/google/OkHttpAPIProvider.java
+++ b/src/main/java/somethingrandom/dataaccess/google/OkHttpAPIProvider.java
@@ -7,10 +7,22 @@ import somethingrandom.dataaccess.google.auth.Token;
 
 import java.io.IOException;
 
+/**
+ * OkHttpAPIProvider is an API provider that uses the OkHttp3 library to make
+ * its requests.
+ *
+ * This is the primary one used in Brainsweep as of writing.
+ */
 class OkHttpAPIProvider implements APIProvider {
     private final OkHttpClient client;
     private final Token token;
 
+    /**
+     * Creates an API provider for the given HTTP client and token.
+     *
+     * @param client The client to execute requests with.
+     * @param token The token to authenticate requests with.
+     */
     public OkHttpAPIProvider(OkHttpClient client, Token token) {
         this.client = client;
         this.token = token;

--- a/src/main/java/somethingrandom/dataaccess/google/OkHttpAPIProvider.java
+++ b/src/main/java/somethingrandom/dataaccess/google/OkHttpAPIProvider.java
@@ -1,0 +1,36 @@
+package somethingrandom.dataaccess.google;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.json.JSONObject;
+import somethingrandom.dataaccess.google.auth.AuthenticationException;
+import somethingrandom.dataaccess.google.auth.Token;
+
+import java.io.IOException;
+
+public class OkHttpAPIProvider implements APIProvider {
+    private final OkHttpClient client;
+    private final Token token;
+
+    public OkHttpAPIProvider(OkHttpClient client, Token token) {
+        this.client = client;
+        this.token = token;
+    }
+
+    @Override
+    public JSONObject request(String url) throws IOException, AuthenticationException {
+        Request request = new Request.Builder()
+            .url(url)
+            .addHeader("Authorization", "Bearer " + token.getToken())
+            .get().build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful() || response.body() == null) {
+                throw new IOException(response.message());
+            }
+
+            return new JSONObject(response.body().string());
+        }
+    }
+}

--- a/src/main/java/somethingrandom/dataaccess/google/OkHttpAPIProvider.java
+++ b/src/main/java/somethingrandom/dataaccess/google/OkHttpAPIProvider.java
@@ -1,15 +1,13 @@
 package somethingrandom.dataaccess.google;
 
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
+import okhttp3.*;
 import org.json.JSONObject;
 import somethingrandom.dataaccess.google.auth.AuthenticationException;
 import somethingrandom.dataaccess.google.auth.Token;
 
 import java.io.IOException;
 
-public class OkHttpAPIProvider implements APIProvider {
+class OkHttpAPIProvider implements APIProvider {
     private final OkHttpClient client;
     private final Token token;
 
@@ -19,9 +17,10 @@ public class OkHttpAPIProvider implements APIProvider {
     }
 
     @Override
-    public JSONObject request(String url) throws IOException, AuthenticationException {
+    public JSONObject request(Body body, String url) throws IOException, AuthenticationException {
         Request request = new Request.Builder()
             .url(url)
+            .method(body.getMethod(), RequestBody.create(body.getContent(), MediaType.get(body.getMimeType())))
             .addHeader("Authorization", "Bearer " + token.getToken())
             .get().build();
 

--- a/src/main/java/somethingrandom/dataaccess/google/OkHttpAPIProvider.java
+++ b/src/main/java/somethingrandom/dataaccess/google/OkHttpAPIProvider.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 /**
  * OkHttpAPIProvider is an API provider that uses the OkHttp3 library to make
  * its requests.
- *
+ * <p>
  * This is the primary one used in Brainsweep as of writing.
  */
 class OkHttpAPIProvider implements APIProvider {

--- a/src/main/java/somethingrandom/dataaccess/google/OkHttpAPIProvider.java
+++ b/src/main/java/somethingrandom/dataaccess/google/OkHttpAPIProvider.java
@@ -29,10 +29,17 @@ class OkHttpAPIProvider implements APIProvider {
     }
 
     @Override
-    public JSONObject request(Body body, String url) throws IOException, AuthenticationException {
+    public JSONObject request(APIRequestBody body, String url) throws IOException, AuthenticationException {
+        RequestBody requestBody;
+        if (body.getContent() == null) {
+            requestBody = null;
+        } else {
+            requestBody = RequestBody.create(body.getContent(), MediaType.get(body.getMimeType()));
+        }
+
         Request request = new Request.Builder()
             .url(url)
-            .method(body.getMethod(), RequestBody.create(body.getContent(), MediaType.get(body.getMimeType())))
+            .method(body.getMethod(), requestBody)
             .addHeader("Authorization", "Bearer " + token.getToken())
             .get().build();
 

--- a/src/main/java/somethingrandom/dataaccess/google/auth/AuthenticationException.java
+++ b/src/main/java/somethingrandom/dataaccess/google/auth/AuthenticationException.java
@@ -2,12 +2,26 @@ package somethingrandom.dataaccess.google.auth;
 
 import somethingrandom.usecase.DataAccessException;
 
+/**
+ * An AuthenticationException represents an error that specifically occurred
+ * while authentication, probably while refreshing a token.
+ */
 public class AuthenticationException extends DataAccessException {
+    /**
+     * Creates a new AuthenticationException with the provided message.
+     *
+     * @param message The message to associate with the exception.
+     */
     public AuthenticationException(String message) {
         super(message);
     }
 
-    public AuthenticationException(Exception e) {
+    /**
+     * Creates a new exception that 'wraps' the throwable.
+     *
+     * @param e The throwable to associate.
+     */
+    public AuthenticationException(Throwable e) {
         super(e);
     }
 }

--- a/src/main/java/somethingrandom/dataaccess/google/auth/AuthenticationException.java
+++ b/src/main/java/somethingrandom/dataaccess/google/auth/AuthenticationException.java
@@ -1,6 +1,8 @@
 package somethingrandom.dataaccess.google.auth;
 
-public class AuthenticationException extends Exception {
+import somethingrandom.usecase.DataAccessException;
+
+public class AuthenticationException extends DataAccessException {
     public AuthenticationException(String message) {
         super(message);
     }

--- a/src/main/java/somethingrandom/dataaccess/google/auth/Token.java
+++ b/src/main/java/somethingrandom/dataaccess/google/auth/Token.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.Nullable;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 /**
@@ -76,6 +77,19 @@ public class Token {
         this.source = source;
         this.clock = clock;
         this.earlyExpiryWindow = earlyExpiryWindow;
+    }
+
+    /**
+     * Creates a token with a constant value.
+     * <p>
+     * This is intended for testing purposes, and is likely not useful outside of that.
+     *
+     * @param value The constant value the token should take on.
+     * @return The newly-created constant token.
+     */
+    public static Token constant(String value) {
+        return new Token(() -> new Token.ExpiringToken(value, Instant.MAX),
+            Clock.fixed(Instant.MIN, ZoneId.of("UTC")));
     }
 
     /**

--- a/src/main/java/somethingrandom/dataaccess/google/tasks/GoogleTasksDataAccessObject.java
+++ b/src/main/java/somethingrandom/dataaccess/google/tasks/GoogleTasksDataAccessObject.java
@@ -4,6 +4,12 @@ import somethingrandom.entity.Item;
 import somethingrandom.usecase.AddItemDataAccessInterface;
 import somethingrandom.usecase.DataAccessException;
 
+/**
+ * Implements an interface to store items in the Google Tasks API.
+ *
+ * The API is
+ * <a href="https://developers.google.com/tasks/reference/rest">published online</a>.
+ */
 public class GoogleTasksDataAccessObject implements AddItemDataAccessInterface {
     @Override
     public void save(Item item) throws DataAccessException {

--- a/src/main/java/somethingrandom/dataaccess/google/tasks/GoogleTasksDataAccessObject.java
+++ b/src/main/java/somethingrandom/dataaccess/google/tasks/GoogleTasksDataAccessObject.java
@@ -11,6 +11,12 @@ import somethingrandom.usecase.DataAccessException;
  * <a href="https://developers.google.com/tasks/reference/rest">published online</a>.
  */
 public class GoogleTasksDataAccessObject implements AddItemDataAccessInterface {
+    private final TaskList taskList;
+
+    public GoogleTasksDataAccessObject(TaskList list) {
+        this.taskList = list;
+    }
+
     @Override
     public void save(Item item) throws DataAccessException {
         throw new RuntimeException("not implemented");

--- a/src/main/java/somethingrandom/dataaccess/google/tasks/GoogleTasksDataAccessObject.java
+++ b/src/main/java/somethingrandom/dataaccess/google/tasks/GoogleTasksDataAccessObject.java
@@ -6,7 +6,7 @@ import somethingrandom.usecase.DataAccessException;
 
 /**
  * Implements an interface to store items in the Google Tasks API.
- *
+ * <p>
  * The API is
  * <a href="https://developers.google.com/tasks/reference/rest">published online</a>.
  */

--- a/src/main/java/somethingrandom/dataaccess/google/tasks/TaskAccount.java
+++ b/src/main/java/somethingrandom/dataaccess/google/tasks/TaskAccount.java
@@ -11,13 +11,35 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * A TaskAccount represents a Google account with contained Google Tasks lists.
+ * <p>
+ * Google Tasks stores the tasks a user has in a series of lists. In order to
+ * insert a task, we need to know which task to put it in.
+ * <p>
+ * The main/only reason to use this is to iterate the lists that the account
+ * contains; it doesn't have anything else about the account.
+ */
 public class TaskAccount {
     private final APIProvider provider;
 
+    /**
+     * Creates a new TaskAccount for the API provider.
+     * <p>
+     * This will access the account of the user's token.
+     *
+     * @param provider The provider to connect with.
+     */
     public TaskAccount(APIProvider provider) {
         this.provider = provider;
     }
 
+    /**
+     * Creates an iterator through the user's list of tasks.
+     *
+     * @return An iterator over the account's list of tasks.
+     * @throws DataAccessException if the API call fails
+     */
     public Iterator<TaskList> iterateLists() throws DataAccessException {
         JSONObject result;
         try {
@@ -49,6 +71,13 @@ public class TaskAccount {
         return found.iterator();
     }
 
+    /**
+     * Finds the task list in this account with the provided identifier.
+     *
+     * @param name The name to assign.
+     * @return the task list, or an empty Optional if it was not found.
+     * @throws DataAccessException if the API call fails
+     */
     public Optional<TaskList> findTaskListByIdentifier(String name) throws DataAccessException {
         for (Iterator<TaskList> it = iterateLists(); it.hasNext(); ) {
             TaskList tl = it.next();

--- a/src/main/java/somethingrandom/dataaccess/google/tasks/TaskAccount.java
+++ b/src/main/java/somethingrandom/dataaccess/google/tasks/TaskAccount.java
@@ -21,7 +21,7 @@ public class TaskAccount {
     public Iterator<TaskList> iterateLists() throws DataAccessException {
         JSONObject result;
         try {
-            result = provider.request("https://tasks.googleapis.com/tasks/v1/users/@me/lists");
+            result = provider.request(new APIProvider.GetBody(), "https://tasks.googleapis.com/tasks/v1/users/@me/lists");
         } catch (IOException e) {
             throw new DataAccessException(e);
         }

--- a/src/main/java/somethingrandom/dataaccess/google/tasks/TaskAccount.java
+++ b/src/main/java/somethingrandom/dataaccess/google/tasks/TaskAccount.java
@@ -3,6 +3,7 @@ package somethingrandom.dataaccess.google.tasks;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import somethingrandom.dataaccess.google.APIProvider;
+import somethingrandom.dataaccess.google.APIRequestBody;
 import somethingrandom.usecase.DataAccessException;
 
 import java.io.IOException;
@@ -43,7 +44,7 @@ public class TaskAccount {
     public Iterator<TaskList> iterateLists() throws DataAccessException {
         JSONObject result;
         try {
-            result = provider.request(new APIProvider.GetBody(), "https://tasks.googleapis.com/tasks/v1/users/@me/lists");
+            result = provider.request(new APIRequestBody.GetBody(), "https://tasks.googleapis.com/tasks/v1/users/@me/lists");
         } catch (IOException e) {
             throw new DataAccessException(e);
         }

--- a/src/main/java/somethingrandom/dataaccess/google/tasks/TaskAccount.java
+++ b/src/main/java/somethingrandom/dataaccess/google/tasks/TaskAccount.java
@@ -1,0 +1,62 @@
+package somethingrandom.dataaccess.google.tasks;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import somethingrandom.dataaccess.google.APIProvider;
+import somethingrandom.usecase.DataAccessException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+public class TaskAccount {
+    private final APIProvider provider;
+
+    public TaskAccount(APIProvider provider) {
+        this.provider = provider;
+    }
+
+    public Iterator<TaskList> iterateLists() throws DataAccessException {
+        JSONObject result;
+        try {
+            result = provider.request("https://tasks.googleapis.com/tasks/v1/users/@me/lists");
+        } catch (IOException e) {
+            throw new DataAccessException(e);
+        }
+
+        if (!result.getString("kind").equals("tasks#taskLists")) {
+            throw new DataAccessException("Task list has invalid format");
+        }
+
+        JSONArray items = result.getJSONArray("items");
+        List<TaskList> found = new ArrayList<>();
+        for (int i = 0; i < items.length(); i++) {
+            JSONObject taskList = items.getJSONObject(i);
+            if (!taskList.optString("kind", "").equals("tasks#taskList")) {
+                throw new DataAccessException("Task list has invalid type");
+            }
+
+            Object id = taskList.opt("id");
+            if (!(id instanceof String)) {
+                throw new DataAccessException("Task list is missing ID");
+            }
+
+            found.add(new TaskList(provider, (String) id));
+        }
+
+        return found.iterator();
+    }
+
+    public Optional<TaskList> findTaskListByIdentifier(String name) throws DataAccessException {
+        for (Iterator<TaskList> it = iterateLists(); it.hasNext(); ) {
+            TaskList tl = it.next();
+            if (tl.getIdentifier().equals(name)) {
+                return Optional.of(tl);
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/somethingrandom/dataaccess/google/tasks/TaskList.java
+++ b/src/main/java/somethingrandom/dataaccess/google/tasks/TaskList.java
@@ -1,78 +1,14 @@
 package somethingrandom.dataaccess.google.tasks;
 
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import somethingrandom.dataaccess.google.auth.Token;
-import somethingrandom.usecase.DataAccessException;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
+import somethingrandom.dataaccess.google.APIProvider;
 
 public class TaskList {
-    private final Token token;
+    private final APIProvider provider;
     private final String identifier;
 
-    private TaskList(Token token, String identifier) {
-        this.token = token;
+    TaskList(APIProvider provider, String identifier) {
+        this.provider = provider;
         this.identifier = identifier;
-    }
-
-    static Iterator<TaskList> iterateLists(OkHttpClient client, Token token) throws DataAccessException {
-        Request request = new Request.Builder()
-            .url("https://tasks.googleapis.com/tasks/v1/users/@me/lists")
-            .addHeader("Authorization", "Bearer " + token.getToken())
-            .get().build();
-
-        try (Response response = client.newCall(request).execute()) {
-            if (!response.isSuccessful() || response.body() == null) {
-                throw new DataAccessException("Failed to get task list: " + response.message());
-            }
-
-            return iterateLists(token, new JSONObject(response.body().string()));
-        } catch (IOException e) {
-            throw new DataAccessException(e);
-        }
-    }
-
-    static Iterator<TaskList> iterateLists(Token token, JSONObject object) throws DataAccessException {
-        if (!object.getString("kind").equals("tasks#taskLists")) {
-            throw new DataAccessException("Task list has invalid format");
-        }
-
-        JSONArray items = object.getJSONArray("items");
-        List<TaskList> found = new ArrayList<>();
-        for (int i = 0; i < items.length(); i++) {
-            JSONObject taskList = items.getJSONObject(i);
-            if (!taskList.optString("kind", "").equals("tasks#taskList")){
-                throw new DataAccessException("Task list has invalid type");
-            }
-
-            Object id = taskList.opt("id");
-            if (!(id instanceof String)) {
-                throw new DataAccessException("Task list is missing ID");
-            }
-
-            found.add(new TaskList(token, (String)id));
-        }
-
-        return found.iterator();
-    }
-
-    public static Optional<TaskList> findTaskListByName(OkHttpClient client, Token token, String name) throws DataAccessException {
-        for (Iterator<TaskList> it = iterateLists(client, token); it.hasNext(); ) {
-            TaskList tl = it.next();
-            if (tl.getIdentifier().equals(name)) {
-                return Optional.of(tl);
-            }
-        }
-
-        return Optional.empty();
     }
 
     public String getIdentifier() {

--- a/src/main/java/somethingrandom/dataaccess/google/tasks/TaskList.java
+++ b/src/main/java/somethingrandom/dataaccess/google/tasks/TaskList.java
@@ -1,0 +1,81 @@
+package somethingrandom.dataaccess.google.tasks;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import somethingrandom.dataaccess.google.auth.Token;
+import somethingrandom.usecase.DataAccessException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+public class TaskList {
+    private final Token token;
+    private final String identifier;
+
+    private TaskList(Token token, String identifier) {
+        this.token = token;
+        this.identifier = identifier;
+    }
+
+    static Iterator<TaskList> iterateLists(OkHttpClient client, Token token) throws DataAccessException {
+        Request request = new Request.Builder()
+            .url("https://tasks.googleapis.com/tasks/v1/users/@me/lists")
+            .addHeader("Authorization", "Bearer " + token.getToken())
+            .get().build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful() || response.body() == null) {
+                throw new DataAccessException("Failed to get task list: " + response.message());
+            }
+
+            return iterateLists(token, new JSONObject(response.body().string()));
+        } catch (IOException e) {
+            throw new DataAccessException(e);
+        }
+    }
+
+    static Iterator<TaskList> iterateLists(Token token, JSONObject object) throws DataAccessException {
+        if (!object.getString("kind").equals("tasks#taskLists")) {
+            throw new DataAccessException("Task list has invalid format");
+        }
+
+        JSONArray items = object.getJSONArray("items");
+        List<TaskList> found = new ArrayList<>();
+        for (int i = 0; i < items.length(); i++) {
+            JSONObject taskList = items.getJSONObject(i);
+            if (!taskList.optString("kind", "").equals("tasks#taskList")){
+                throw new DataAccessException("Task list has invalid type");
+            }
+
+            Object id = taskList.opt("id");
+            if (!(id instanceof String)) {
+                throw new DataAccessException("Task list is missing ID");
+            }
+
+            found.add(new TaskList(token, (String)id));
+        }
+
+        return found.iterator();
+    }
+
+    public static Optional<TaskList> findTaskListByName(OkHttpClient client, Token token, String name) throws DataAccessException {
+        for (Iterator<TaskList> it = iterateLists(client, token); it.hasNext(); ) {
+            TaskList tl = it.next();
+            if (tl.getIdentifier().equals(name)) {
+                return Optional.of(tl);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+}

--- a/src/main/java/somethingrandom/usecase/DataAccessException.java
+++ b/src/main/java/somethingrandom/usecase/DataAccessException.java
@@ -1,3 +1,11 @@
 package somethingrandom.usecase;
 
-public class DataAccessException extends Exception { }
+public class DataAccessException extends Exception {
+    public DataAccessException(Exception e) {
+        super(e);
+    }
+
+    public DataAccessException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/somethingrandom/usecase/DataAccessException.java
+++ b/src/main/java/somethingrandom/usecase/DataAccessException.java
@@ -1,11 +1,31 @@
 package somethingrandom.usecase;
 
+/**
+ * Represents an error that occurred while accessing data.
+ *
+ * This is used to indicate that fetching the data failed for some reason in
+ * a way the use-cases need to worry about; possibilities include a API error,
+ * network error, or similar.
+ *
+ * (This is in the usecase package so usecase doesn't know anything about
+ * data_access, i.e. to comply with the dependency rule.)
+ */
 public class DataAccessException extends Exception {
-    public DataAccessException(Exception e) {
-        super(e);
-    }
-
+    /**
+     * Creates a new DataAccessException with the provided message.
+     *
+     * @param message The message to associate.
+     */
     public DataAccessException(String message) {
         super(message);
+    }
+
+    /**
+     * Creates a new DataAccessException wrapping the provided exception.
+     *
+     * @param e The throwable to wrap.
+     */
+    public DataAccessException(Throwable e) {
+        super(e);
     }
 }

--- a/src/test/java/somethingrandom/dataaccess/google/auth/TokenTest.java
+++ b/src/test/java/somethingrandom/dataaccess/google/auth/TokenTest.java
@@ -111,4 +111,13 @@ public class TokenTest {
         clock.setInstant(expiresWhen);
         assertEquals("token #1", token.getToken());
     }
+
+    @Test
+    public void shouldNotChangeConstantToken() throws AuthenticationException {
+        // Assume the token at least will change immediately, since we can't mock out
+        // the clock.
+        Token t = Token.constant("abc");
+        assertEquals(t.getToken(), "abc");
+        assertEquals(t.getToken(), "abc");
+    }
 }

--- a/src/test/java/somethingrandom/dataaccess/google/tasks/TaskAccountTest.java
+++ b/src/test/java/somethingrandom/dataaccess/google/tasks/TaskAccountTest.java
@@ -1,7 +1,7 @@
 package somethingrandom.dataaccess.google.tasks;
 
-import org.json.JSONObject;
 import org.junit.Test;
+import somethingrandom.dataaccess.google.APIProvider;
 import somethingrandom.dataaccess.google.auth.Token;
 import somethingrandom.usecase.DataAccessException;
 
@@ -9,13 +9,13 @@ import java.util.Iterator;
 
 import static org.junit.Assert.*;
 
-public class TaskListTest {
+public class TaskAccountTest {
     private final Token token = Token.constant("token");
 
     @Test
     public void iterateListsThrowsOnIncorrectRootKind() {
         assertThrows(DataAccessException.class, () -> {
-            TaskList.iterateLists(token, new JSONObject("{\"kind\": \"not the right kind\"}"));
+            new TaskAccount(new APIProvider.Constant("{\"kind\": \"not the right kind\"}")).iterateLists();
         });
     }
 
@@ -23,13 +23,14 @@ public class TaskListTest {
     public void shouldThrowIfNoItemsKeyPresent() {
         // TODO We should ideally wrap this ourselves.
         assertThrows(Exception.class, () -> {
-            TaskList.iterateLists(token, new JSONObject("{\"kind\": \"tasks#taskLists\"}"));
+            new TaskAccount(new APIProvider.Constant("{\"kind\": \"tasks#taskLists\"}")).iterateLists();
         });
     }
 
     @Test
     public void shouldHandleEmptyItemsList() throws DataAccessException {
-        assertFalse(TaskList.iterateLists(token, new JSONObject("{\"kind\": \"tasks#taskLists\", \"items\": []}")).hasNext());
+        APIProvider provider = new APIProvider.Constant("{\"kind\": \"tasks#taskLists\", \"items\": []}");
+        assertFalse(new TaskAccount(provider).iterateLists().hasNext());
     }
 
     @Test
@@ -44,7 +45,7 @@ public class TaskListTest {
         """;
 
         assertThrows(DataAccessException.class, () -> {
-            TaskList.iterateLists(token, new JSONObject(DATA));
+            new TaskAccount(new APIProvider.Constant(DATA)).iterateLists();
         });
     }
 
@@ -62,7 +63,7 @@ public class TaskListTest {
         """;
 
         assertThrows(DataAccessException.class, () -> {
-            TaskList.iterateLists(token, new JSONObject(DATA));
+            new TaskAccount(new APIProvider.Constant(DATA)).iterateLists();
         });
     }
 
@@ -84,7 +85,7 @@ public class TaskListTest {
         }
         """;
 
-        Iterator<TaskList> tls = TaskList.iterateLists(token, new JSONObject(DATA));
+        Iterator<TaskList> tls = new TaskAccount(new APIProvider.Constant(DATA)).iterateLists();
         assertEquals("abc", tls.next().getIdentifier());
         assertEquals("def", tls.next().getIdentifier());
         assertFalse(tls.hasNext());

--- a/src/test/java/somethingrandom/dataaccess/google/tasks/TaskListTest.java
+++ b/src/test/java/somethingrandom/dataaccess/google/tasks/TaskListTest.java
@@ -1,0 +1,92 @@
+package somethingrandom.dataaccess.google.tasks;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import somethingrandom.dataaccess.google.auth.Token;
+import somethingrandom.usecase.DataAccessException;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+public class TaskListTest {
+    private final Token token = Token.constant("token");
+
+    @Test
+    public void iterateListsThrowsOnIncorrectRootKind() {
+        assertThrows(DataAccessException.class, () -> {
+            TaskList.iterateLists(token, new JSONObject("{\"kind\": \"not the right kind\"}"));
+        });
+    }
+
+    @Test
+    public void shouldThrowIfNoItemsKeyPresent() {
+        // TODO We should ideally wrap this ourselves.
+        assertThrows(Exception.class, () -> {
+            TaskList.iterateLists(token, new JSONObject("{\"kind\": \"tasks#taskLists\"}"));
+        });
+    }
+
+    @Test
+    public void shouldHandleEmptyItemsList() throws DataAccessException {
+        assertFalse(TaskList.iterateLists(token, new JSONObject("{\"kind\": \"tasks#taskLists\", \"items\": []}")).hasNext());
+    }
+
+    @Test
+    public void shouldTestEveryItemHasCorrectKind() {
+        final String DATA = """
+        {
+            "kind": "tasks#taskLists",
+            "items": [
+                { "kind": "not correct" }
+            ]
+        }
+        """;
+
+        assertThrows(DataAccessException.class, () -> {
+            TaskList.iterateLists(token, new JSONObject(DATA));
+        });
+    }
+
+    @Test
+    public void shouldTestIdIsPresent() {
+        final String DATA = """
+        {
+            "kind": "tasks#taskLists",
+            "items": [
+                {
+                    "kind": "tasks#taskList"
+                }
+            ]
+        }
+        """;
+
+        assertThrows(DataAccessException.class, () -> {
+            TaskList.iterateLists(token, new JSONObject(DATA));
+        });
+    }
+
+    @Test
+    public void shouldCreateTaskListForEachItem() throws DataAccessException {
+        final String DATA = """
+        {
+            "kind": "tasks#taskLists",
+            "items": [
+                {
+                    "kind": "tasks#taskList",
+                    "id": "abc"
+                },
+                {
+                    "kind": "tasks#taskList",
+                    "id": "def"
+                }
+            ]
+        }
+        """;
+
+        Iterator<TaskList> tls = TaskList.iterateLists(token, new JSONObject(DATA));
+        assertEquals("abc", tls.next().getIdentifier());
+        assertEquals("def", tls.next().getIdentifier());
+        assertFalse(tls.hasNext());
+    }
+}


### PR DESCRIPTION
This patch adds the OAuth implementation based on the one I wrote for the initial proposal, and the start of the Google Tasks connection. It isn't quite ready yet, since I'd like to have `GoogleTasksDataAccessObject.save` do something, but otherwise it is mostly ok hopefully.

It's split into three packages:

* `somethingrandom.data_access.google.auth`, which works on OAuth;
* `somethingrandom.data_access.google.tasks`, which is the Google Tasks integration;
* `somethingrandom.data_access.google`, which is the overall integration that'll eventually also use Google Keep when needed.

Most of `.auth` is documented, I need to write more for the other parts. Tests are available for a decent chunk.