### PR TITLE
Reassign source folders for IntelliJ IDEA

### DIFF
--- a/brainsweep.iml
+++ b/brainsweep.iml
@@ -2,7 +2,8 @@
 <module version="4">
   <component name="AdditionalModuleElements">
     <content url="file://$MODULE_DIR$" dumb="true">
-      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test" isTestSource="true" />
     </content>
   </component>
 </module>


### PR DESCRIPTION
Currently, src/ is defined as the source folder. However, we follow a more Maven-esque layout, where src/main is the source folder and src/test the test folder.

While I don't think this problem has many practical effects, it does make the Project view in the IDE look weird: it hides the test/ folder entirely. (I also just had some tests mess up as a result, since IntelliJ thought the package was wrong.)

Fix this by having two separate directories, src/main and src/test.