### PR TITLE
Reorganize the data access demo, remove Google Keep promises, change login scopes

### DIFF
--- a/src/main/java/somethingrandom/dataaccess/google/Demo.java
+++ b/src/main/java/somethingrandom/dataaccess/google/Demo.java
@@ -1,0 +1,25 @@
+package somethingrandom.dataaccess.google;
+
+import okhttp3.OkHttpClient;
+import somethingrandom.dataaccess.google.auth.LoginFlow;
+import somethingrandom.dataaccess.google.auth.S256CodeVerifier;
+import somethingrandom.entity.ActionableItem;
+import somethingrandom.entity.ReferenceItem;
+import somethingrandom.usecase.DataAccessException;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+public class Demo {
+    public static void main(String[] args) throws DataAccessException {
+        OkHttpClient client = new OkHttpClient();
+        LoginFlow loginFlow = new LoginFlow(client, System.getenv("OAUTH_CLIENT_SECRET"), new S256CodeVerifier(new SecureRandom()), GoogleDataAccessObject.getScopes());
+
+        GoogleDataAccessObject dao = new GoogleDataAccessObject(client, loginFlow.execute(), "Brainsweep");
+        dao.save(new ReferenceItem("Hello, world!", UUID.randomUUID(), Instant.now(), "This is a description."));
+        dao.save(new ActionableItem("Hello, world!", UUID.randomUUID(), Instant.now().plus(1, ChronoUnit.DAYS), Duration.of(5, ChronoUnit.MINUTES)));
+    }
+}

--- a/src/main/java/somethingrandom/dataaccess/google/GoogleDataAccessObject.java
+++ b/src/main/java/somethingrandom/dataaccess/google/GoogleDataAccessObject.java
@@ -14,10 +14,10 @@ import java.util.Optional;
 
 /**
  * GoogleDataAccessObject is a generic data access object to interact
- * with either Google Keep or Google Tasks.
+ * with Google Tasks, or any other Google services that may be added.
  * <p>
- * It automatically selects the backend corresponding: Keep for reference
- * items, and Tasks for others.
+ * Currently, Google Tasks is always used; adding Google Keep support,
+ * for example, may be possible in an enterprise scenario.
  */
 public class GoogleDataAccessObject implements AddItemDataAccessInterface {
     private final GoogleTasksDataAccessObject tasksDAO;

--- a/src/main/java/somethingrandom/dataaccess/google/GoogleDataAccessObject.java
+++ b/src/main/java/somethingrandom/dataaccess/google/GoogleDataAccessObject.java
@@ -36,6 +36,12 @@ public class GoogleDataAccessObject implements AddItemDataAccessInterface {
         this.tasksDAO = createTasksDAO(provider, taskListName);
     }
 
+    public static String[] getScopes() {
+        return new String[] {
+            GoogleTasksDataAccessObject.getScope(),
+        };
+    }
+
     @NotNull
     private static GoogleTasksDataAccessObject createTasksDAO(APIProvider provider, String taskListName) throws DataAccessException {
         TaskAccount account = new TaskAccount(provider);

--- a/src/main/java/somethingrandom/dataaccess/google/auth/LoginFlow.java
+++ b/src/main/java/somethingrandom/dataaccess/google/auth/LoginFlow.java
@@ -19,11 +19,13 @@ public class LoginFlow {
     private final OkHttpClient httpClient;
     private final String clientSecret;
     private int usedPort = 0;
+    private String[] scopes;
 
-    public LoginFlow(OkHttpClient httpClient, String clientSecret, CodeVerifier verifier) {
+    public LoginFlow(OkHttpClient httpClient, String clientSecret, CodeVerifier verifier, String[] scopes) {
         this.httpClient = httpClient;
         this.clientSecret = clientSecret;
         this.verifier = verifier;
+        this.scopes = scopes;
 
         if (clientSecret == null) {
             throw new IllegalArgumentException("clientSecret cannot be null");
@@ -58,7 +60,7 @@ public class LoginFlow {
         String uri = "https://accounts.google.com/o/oauth2/v2/auth";
         uri += "?client_id=" + OAUTH_CLIENT_ID;
         uri += "&redirect_uri=http://127.0.0.1:" + usedPort;
-        uri += "&scope=https://www.googleapis.com/auth/calendar";
+        uri += "&scope=" + String.join("+", scopes);
         uri += "&code_challenge=" + verifier.getCodeChallenge();
         uri += "&code_challenge_method=" + verifier.getMethodName();
         uri += "&response_type=code";

--- a/src/main/java/somethingrandom/dataaccess/google/auth/LoginFlow.java
+++ b/src/main/java/somethingrandom/dataaccess/google/auth/LoginFlow.java
@@ -20,14 +20,6 @@ public class LoginFlow {
     private final String clientSecret;
     private int usedPort = 0;
 
-    public static void main(String[] args) throws AuthenticationException, IOException {
-        LoginFlow c = new LoginFlow(new OkHttpClient(), System.getenv("OAUTH_CLIENT_SECRET"), new S256CodeVerifier(new SecureRandom()));
-        Token t = c.execute();
-        System.out.println("got authorization token: " + t.getToken().substring(0, 5) + "...");
-
-        c.addEvent(t, "It works on October 2nd");
-    }
-
     public LoginFlow(OkHttpClient httpClient, String clientSecret, CodeVerifier verifier) {
         this.httpClient = httpClient;
         this.clientSecret = clientSecret;
@@ -104,25 +96,5 @@ public class LoginFlow {
 
     private String getRedirectUrl() {
         return "http://127.0.0.1:" + usedPort;
-    }
-
-    private void addEvent(Token token, String eventName) throws IOException, AuthenticationException {
-        HttpUrl url = new HttpUrl.Builder()
-                .scheme("https")
-                .host("www.googleapis.com")
-                .addPathSegments("calendar/v3/calendars/primary/events/quickAdd")
-                .addQueryParameter("text", eventName)
-                .build();
-
-        Request req = new Request.Builder()
-                .post(RequestBody.create(new byte[0]))
-                .url(url)
-                .addHeader("Authorization", "Bearer " + token.getToken())
-                .build();
-
-        try (Response resp = httpClient.newCall(req).execute()) {
-            System.out.println("event creation gave " + resp.code() + ": " + resp.message());
-            System.out.println(resp.body().string());
-        }
     }
 }

--- a/src/main/java/somethingrandom/dataaccess/google/tasks/GoogleTasksDataAccessObject.java
+++ b/src/main/java/somethingrandom/dataaccess/google/tasks/GoogleTasksDataAccessObject.java
@@ -17,6 +17,10 @@ public class GoogleTasksDataAccessObject implements AddItemDataAccessInterface {
         this.taskList = list;
     }
 
+    public static String getScope() {
+        return "https://www.googleapis.com/auth/tasks";
+    }
+
     @Override
     public void save(Item item) throws DataAccessException {
         throw new RuntimeException("not implemented");

--- a/src/main/java/somethingrandom/dataaccess/google/tasks/TaskAccount.java
+++ b/src/main/java/somethingrandom/dataaccess/google/tasks/TaskAccount.java
@@ -61,19 +61,24 @@ public class TaskAccount {
                 throw new DataAccessException("Task list has invalid type");
             }
 
+            Object title = taskList.opt("title");
+            if (!(title instanceof String)) {
+                throw new DataAccessException("Task list is missing title");
+            }
+
             Object id = taskList.opt("id");
             if (!(id instanceof String)) {
                 throw new DataAccessException("Task list is missing ID");
             }
 
-            found.add(new TaskList(provider, (String) id));
+            found.add(new TaskList(provider, (String)title, (String) id));
         }
 
         return found.iterator();
     }
 
     /**
-     * Finds the task list in this account with the provided identifier.
+     * Finds the task list in this account with the provided title.
      *
      * @param name The name to assign.
      * @return the task list, or an empty Optional if it was not found.
@@ -82,7 +87,7 @@ public class TaskAccount {
     public Optional<TaskList> findTaskListByIdentifier(String name) throws DataAccessException {
         for (Iterator<TaskList> it = iterateLists(); it.hasNext(); ) {
             TaskList tl = it.next();
-            if (tl.getIdentifier().equals(name)) {
+            if (tl.getTitle().equals(name)) {
                 return Optional.of(tl);
             }
         }

--- a/src/main/java/somethingrandom/dataaccess/google/tasks/TaskList.java
+++ b/src/main/java/somethingrandom/dataaccess/google/tasks/TaskList.java
@@ -5,13 +5,19 @@ import somethingrandom.dataaccess.google.APIProvider;
 public class TaskList {
     private final APIProvider provider;
     private final String identifier;
+    private final String title;
 
-    TaskList(APIProvider provider, String identifier) {
+    TaskList(APIProvider provider, String title, String identifier) {
         this.provider = provider;
         this.identifier = identifier;
+        this.title = title;
     }
 
     public String getIdentifier() {
         return identifier;
+    }
+
+    public String getTitle() {
+        return title;
     }
 }

--- a/src/test/java/somethingrandom/dataaccess/google/tasks/TaskAccountTest.java
+++ b/src/test/java/somethingrandom/dataaccess/google/tasks/TaskAccountTest.java
@@ -50,13 +50,51 @@ public class TaskAccountTest {
     }
 
     @Test
-    public void shouldTestIdIsPresent() {
+    public void shouldTestIdAndTitleArePresent() {
         final String DATA = """
         {
             "kind": "tasks#taskLists",
             "items": [
                 {
                     "kind": "tasks#taskList"
+                }
+            ]
+        }
+        """;
+
+        assertThrows(DataAccessException.class, () -> {
+            new TaskAccount(new APIProvider.Constant(DATA)).iterateLists();
+        });
+    }
+
+    @Test
+    public void shouldTestTitleIsPresent() {
+        final String DATA = """
+        {
+            "kind": "tasks#taskLists",
+            "items": [
+                {
+                    "kind": "tasks#taskList",
+                    "id": "something"
+                }
+            ]
+        }
+        """;
+
+        assertThrows(DataAccessException.class, () -> {
+            new TaskAccount(new APIProvider.Constant(DATA)).iterateLists();
+        });
+    }
+
+    @Test
+    public void shouldTestIdIsPresent() {
+        final String DATA = """
+        {
+            "kind": "tasks#taskLists",
+            "items": [
+                {
+                    "kind": "tasks#taskList",
+                    "title": "something"
                 }
             ]
         }
@@ -75,19 +113,28 @@ public class TaskAccountTest {
             "items": [
                 {
                     "kind": "tasks#taskList",
-                    "id": "abc"
+                    "id": "abc",
+                    "title": "Tuv"
                 },
                 {
                     "kind": "tasks#taskList",
-                    "id": "def"
+                    "id": "def",
+                    "title": "Xyz"
                 }
             ]
         }
         """;
 
         Iterator<TaskList> tls = new TaskAccount(new APIProvider.Constant(DATA)).iterateLists();
-        assertEquals("abc", tls.next().getIdentifier());
-        assertEquals("def", tls.next().getIdentifier());
+
+        TaskList tl = tls.next();
+        assertEquals("abc", tl.getIdentifier());
+        assertEquals("Tuv", tl.getTitle());
+
+        tl = tls.next();
+        assertEquals("def", tl.getIdentifier());
+        assertEquals("Xyz", tl.getTitle());
+
         assertFalse(tls.hasNext());
     }
 }


### PR DESCRIPTION
The data access demo is moved from LoginFlow to a new Demo class, and now uses the rest of the DA infrastructure from the project instead of doing it itself.

Google Keep turns out to be enterprise-only, so we won't be able to use it. Avoid promising anything in the Javadoc.

In preparation for Keep, have LoginFlow take a list of login scopes instead of hardcoding Calendar. Less useful now, but more flexible if GoogleDataAccessObject gains more features.

Also, look for the title of a task list instead of the IDs when finding one by name. We might want to display the title in the UI, so having it is useful, and it's also more convenient to work with from the Google Tasks web interface.